### PR TITLE
Added reduce output task

### DIFF
--- a/src/lib/kombi/Task/OutputOperator/ReduceOutputTask.py
+++ b/src/lib/kombi/Task/OutputOperator/ReduceOutputTask.py
@@ -1,0 +1,23 @@
+from ..Task import Task
+
+class ReduceOutputTask(Task):
+    """
+    Task used to modify the output by reducing the number of crawlers.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Create a modify crawlers task object.
+        """
+        super(ReduceOutputTask, self).__init__(*args, **kwargs)
+
+        self.setOption('total', 1)
+
+    def _perform(self):
+        """
+        Perform the task.
+        """
+        return self.crawlers()[:-self.option('total')]
+
+
+Task.register('reduceOutput', ReduceOutputTask)

--- a/src/lib/kombi/Task/OutputOperator/__init__.py
+++ b/src/lib/kombi/Task/OutputOperator/__init__.py
@@ -1,3 +1,4 @@
 from .ModifyOutputTask import ModifyOutputTask
 from .LockTask import LockTask
 from .UnlockTask import UnlockTask
+from .ReduceOutputTask import ReduceOutputTask


### PR DESCRIPTION
This pull request adds a new output task designed to reduce the number of crawlers (This is useful when you only need one crawler for the next task).