### PR TITLE
Deprecate name in option visual

### DIFF
--- a/src/lib/kombiqt/OptionVisual/ArrayOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/ArrayOptionVisual.py
@@ -8,11 +8,11 @@ class ArrayOptionVisual(OptionVisual):
     Implement the widget for an array option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create ArrayOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 
@@ -32,7 +32,7 @@ class ArrayOptionVisual(OptionVisual):
         for i, optionValue in enumerate(self.optionValue()):
             optionName = str(i)
             uiHints = itemsUiHints.get(optionName, {})
-            itemWidget = OptionVisual.create(optionName, optionValue, uiHints)
+            itemWidget = OptionVisual.create(optionValue, uiHints)
             itemWidget.valueChanged.connect(functools.partial(self.__onItemValueChanged, i))
 
             label = uiHints.get('label', optionName)

--- a/src/lib/kombiqt/OptionVisual/BoolOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/BoolOptionVisual.py
@@ -7,11 +7,11 @@ class BoolOptionVisual(OptionVisual):
     Implement the widget for a boolean option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create BoolOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/DateOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/DateOptionVisual.py
@@ -7,11 +7,11 @@ class DateOptionVisual(OptionVisual):
     Implement the widget for a date option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create DateOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/DirectoryPathOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/DirectoryPathOptionVisual.py
@@ -10,11 +10,11 @@ class DirectoryPathOptionVisual(OptionVisual):
     Implement the widget for a text option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create DirectoryPathOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/ElementOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/ElementOptionVisual.py
@@ -10,11 +10,11 @@ class ElementOptionVisual(OptionVisual):
     """
     __defaultPreviewHeight = 240
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create ElementOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/FilePathOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/FilePathOptionVisual.py
@@ -10,11 +10,11 @@ class FilePathOptionVisual(OptionVisual):
     Implement the widget for a text option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create FilePathOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/FloatOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/FloatOptionVisual.py
@@ -8,11 +8,11 @@ class FloatOptionVisual(OptionVisual):
     Implement the widget for a float option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create FloatOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/HashmapOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/HashmapOptionVisual.py
@@ -8,11 +8,11 @@ class HashmapOptionVisual(OptionVisual):
     Implement the widget for a hashmap option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create HashmapOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 
@@ -37,7 +37,7 @@ class HashmapOptionVisual(OptionVisual):
             if uiHints.get('hidden', False):
                 continue
 
-            itemWidget = OptionVisual.create(optionName, optionValue, uiHints)
+            itemWidget = OptionVisual.create(optionValue, uiHints)
             itemWidget.valueChanged.connect(functools.partial(self.__onItemValueChanged, optionName))
 
             label = uiHints.get('label', optionName)

--- a/src/lib/kombiqt/OptionVisual/HexColorOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/HexColorOptionVisual.py
@@ -7,11 +7,11 @@ class HexColorOptionVisual(OptionVisual):
     Implement the widget for a hex color option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create HexColorOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/IntOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/IntOptionVisual.py
@@ -6,11 +6,11 @@ class IntOptionVisual(OptionVisual):
     Implement the widget for a float option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create IntOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/LongTextOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/LongTextOptionVisual.py
@@ -7,11 +7,11 @@ class LongTextOptionVisual(OptionVisual):
     Implement the widget for a long text option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create LongTextOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/OptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/OptionVisual.py
@@ -10,13 +10,12 @@ class OptionVisual(QtWidgets.QWidget):
     __registeredFallbackDefaultVisuals = {}
     __registeredOptionVisualExamples = {}
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create an OptionVisual object.
         """
         super().__init__()
 
-        self.__setOptionName(optionName)
         self.__setOptionValue(optionValue)
         self.__setUIHint(uiHints or {})
 
@@ -36,12 +35,6 @@ class OptionVisual(QtWidgets.QWidget):
         """
         return self.__uiHints
 
-    def optionName(self):
-        """
-        Return the option name assigned to the visual during the creation.
-        """
-        return self.__optionName
-
     def optionValue(self):
         """
         Return the option value (this value is updated automatically by the valueChanged signal).
@@ -56,14 +49,6 @@ class OptionVisual(QtWidgets.QWidget):
 
         self.__uiHints = uiHints
 
-    def __setOptionName(self, optionName):
-        """
-        Set the option name.
-        """
-        assert isinstance(optionName, str), "option name needs to be defined as string!"
-
-        self.__optionName = optionName
-
     def __setOptionValue(self, optionValue):
         """
         Set the option value.
@@ -71,7 +56,7 @@ class OptionVisual(QtWidgets.QWidget):
         self.__optionValue = optionValue
 
     @classmethod
-    def create(cls, optionName, optionValue, uiHints=None):
+    def create(cls, optionValue, uiHints=None):
         """
         Factory an option visual widget.
 
@@ -89,10 +74,9 @@ class OptionVisual(QtWidgets.QWidget):
                 if isinstance(optionValue, valueType):
                     registeredName = fallbackRegisteredName
                     break
-        assert registeredName, f"Value '{optionValue}' for option '{optionName}' is not supported!"
+        assert registeredName, f"Value '{optionValue}' for option is not supported!"
 
         return cls.__registeredOptionVisuals[registeredName](
-            optionName,
             optionValue,
             uiHints
         )
@@ -114,7 +98,7 @@ class OptionVisual(QtWidgets.QWidget):
             uiHints = dict(exampleData['uiHints'])
         uiHints['visual'] = registeredOptionVisualName
 
-        return cls.create('example', exampleData['value'], uiHints)
+        return cls.create(exampleData['value'], uiHints)
 
     @classmethod
     def registeredNames(cls):

--- a/src/lib/kombiqt/OptionVisual/PathBrowserOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/PathBrowserOptionVisual.py
@@ -12,11 +12,11 @@ class PathBrowserOptionVisual(OptionVisual):
     doubleClick = QtCore.Signal()
     rootChanged = QtCore.Signal(str)
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create PathBrowserOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 
@@ -31,7 +31,6 @@ class PathBrowserOptionVisual(OptionVisual):
 
         rootPath = self.uiHints().get('rootPath', '').replace('\\', '/')
         self.__rootWidget = DirectoryPathOptionVisual(
-            'root',
             rootPath,
             {
                 'label': self.uiHints().get('rootButtonLabel', '')

--- a/src/lib/kombiqt/OptionVisual/PresetsOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/PresetsOptionVisual.py
@@ -7,11 +7,11 @@ class PresetsOptionVisual(OptionVisual):
     Implement the widget for a presets visual.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create PresetsOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/TextOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/TextOptionVisual.py
@@ -7,11 +7,11 @@ class TextOptionVisual(OptionVisual):
     Implement the widget for a text option.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create TextOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
         self.__pendingTextEdited = False
         self.__buildWidget()
 

--- a/src/lib/kombiqt/OptionVisual/ViewOptionVisual.py
+++ b/src/lib/kombiqt/OptionVisual/ViewOptionVisual.py
@@ -7,11 +7,11 @@ class ViewOptionVisual(OptionVisual):
     Implement a widget that only displays the value.
     """
 
-    def __init__(self, optionName, optionValue, uiHints=None):
+    def __init__(self, optionValue, uiHints=None):
         """
         Create ViewOptionVisual object.
         """
-        super().__init__(optionName, optionValue, uiHints)
+        super().__init__(optionValue, uiHints)
 
         self.__buildWidget()
 

--- a/src/lib/kombiqt/Widget/ExecutionSettingsWidget.py
+++ b/src/lib/kombiqt/Widget/ExecutionSettingsWidget.py
@@ -394,7 +394,7 @@ class ExecutionSettingsWidget(QtWidgets.QTreeWidget):
         if taskHolder.task().hasMetadata(uiOptionMetadataName):
             uiHints = taskHolder.task().metadata(uiOptionMetadataName)
 
-        optionVisualWidget = OptionVisual.create(optionName, optionValue, uiHints)
+        optionVisualWidget = OptionVisual.create(optionValue, uiHints)
         # in case the value has changed during the construction lets update it directly to the task
         if optionVisualWidget.optionValue() != optionValue:
             if taskHolder not in self.__changedOptions:

--- a/src/lib/kombiqt/Window/PreferencesWindow.py
+++ b/src/lib/kombiqt/Window/PreferencesWindow.py
@@ -34,7 +34,7 @@ class PreferencesWindow(QtWidgets.QDialog):
         mainLayout = QtWidgets.QVBoxLayout()
 
         # font setting
-        self.__fontSizeWidget = IntOptionVisual('fontSize', Resource.fontSize(), {"min": 8, "max": 40})
+        self.__fontSizeWidget = IntOptionVisual(Resource.fontSize(), {"min": 8, "max": 40})
         self.__fontSizeWidget.valueChanged.connect(self.__onFontSizeChanged)
         self.__fontPreviewLabelWidget = QtWidgets.QLabel('The quick brown fox jumps over the lazy dog')
         self.__fontPreviewLabelWidget.setObjectName('fontSizePreview')
@@ -44,7 +44,7 @@ class PreferencesWindow(QtWidgets.QDialog):
         mainLayout.addSpacing(20)
 
         # icon size setting
-        self.__listIconSizeWidget = IntOptionVisual('listIconSize', Resource.listIconSize(), {"min": 12, "max": 96})
+        self.__listIconSizeWidget = IntOptionVisual(Resource.listIconSize(), {"min": 12, "max": 96})
         self.__listIconSizeWidget.valueChanged.connect(self.__onListIconSizeChanged)
         self.__listIconPreviewWidget = QtWidgets.QLabel()
         self.__listIconPreviewWidget.setObjectName('listIconSizePreview')

--- a/src/lib/kombiqt/Window/ScriptEditorWindow.py
+++ b/src/lib/kombiqt/Window/ScriptEditorWindow.py
@@ -71,7 +71,6 @@ class ScriptEditorWindow(QtWidgets.QMainWindow):
             rootPath = Resource.userConfig().value('scriptEditorRootPath', pathlib.Path.home().as_posix())
 
         self.__scriptEditorFileBrowser = PathBrowserOptionVisual(
-            'scriptEditor',
             '',
             {
                 'rootPath': rootPath,


### PR DESCRIPTION
This pull request deprecates the need of specifying a name for the option visual.