### PR TITLE
Add confirmation when closing script editor tab

### DIFF
--- a/src/lib/kombiqt/Widget/ScriptEditorTabWidget.py
+++ b/src/lib/kombiqt/Widget/ScriptEditorTabWidget.py
@@ -191,8 +191,22 @@ class ScriptEditorTabWidget(QtWidgets.QTabWidget):
         """
         Triggered when tab close button is pressed.
         """
-        self.removeTab(index)
+        # prompting for confirmation to prevent potential data loss
+        if self.isTabScriptEditor(index):
+            tabWidget = self.widget(index)
+            if tabWidget.filePath() and tabWidget.isModified() or \
+                    len(tabWidget.code()) and not tabWidget.filePath():
+                closeConfirmation = QtWidgets.QMessageBox.question(
+                    self,
+                    'Close Tab: {}'.format(self.tabText(index)),
+                    'Are you sure you want to close? Unsaved changes will be lost.',
+                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                    QtWidgets.QMessageBox.No
+                )
+                if closeConfirmation != QtWidgets.QMessageBox.Yes:
+                    return
 
+        self.removeTab(index)
         self.__bakeTabs()
 
         if not self.count():


### PR DESCRIPTION
This pull request addresses the issue #133 by adding a confirmation when closing a script editor tab with unsaved modifications.